### PR TITLE
fix: ignore xs:unique tag

### DIFF
--- a/out/unique.json
+++ b/out/unique.json
@@ -1,0 +1,25 @@
+{
+  "title": "test/unique.xsd",
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "Address": {
+      "$ref": "#/definitions/AddressCType"
+    }
+  },
+  "required": [
+    "Address"
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "AddressCType": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/test/unique.xsd
+++ b/test/unique.xsd
@@ -1,0 +1,15 @@
+<xs:schema elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:complexType name="AddressCType">
+        <xs:sequence>
+            <xs:element name="Name" type="xs:string" minOccurs="0" maxOccurs="1">
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="Address" type="AddressCType">
+        <xs:unique name="Address_CType1Indexfeld">
+            <xs:selector xpath="Address"/>
+            <xs:field xpath="Name"/>
+        </xs:unique>
+    </xs:element>
+</xs:schema>
+

--- a/xsd2json.js
+++ b/xsd2json.js
@@ -525,7 +525,7 @@ function processChoice(obj, parent, key) {
 }
 
 function removeUnique(obj, parent, key) {
-    if (obj[xsPrefix + "unique"] != null) {
+    if (typeof obj[xsPrefix + "unique"] !== 'undefined') {
         delete obj[xsPrefix + "unique"];
     }
 }

--- a/xsd2json.js
+++ b/xsd2json.js
@@ -524,6 +524,12 @@ function processChoice(obj, parent, key) {
     }
 }
 
+function removeUnique(obj, parent, key) {
+    if (obj[xsPrefix + "unique"] != null) {
+        delete obj[xsPrefix + "unique"];
+    }
+}
+
 function renameObjects(obj, parent, key) {
     if (key == xsPrefix + 'complexType') {
         var name = obj["@name"];
@@ -664,6 +670,9 @@ module.exports = {
         });
         recurse(src, {}, function (src, parent, key) {
             processChoice(src, parent, key);
+        });
+        recurse(src, {}, function (src, parent, key) {
+            removeUnique(src, parent, key);
         });
 
         var obj = {};


### PR DESCRIPTION
Right now, xsd2json adds `xs:unique` constraints as a properties to the parent element, to avoid that simply remove all `xs:unique` constraints as there is no good way to represent them in JSON schema.